### PR TITLE
position error message on radiobuttons

### DIFF
--- a/includes/form/form-validation.php
+++ b/includes/form/form-validation.php
@@ -159,8 +159,10 @@ function buddyforms_jquery_validation() {
 		$form_html .= 'errorPlacement: function(label, element) {
 	            // position error label after generated textarea
 	            if (element.is("textarea")) {
-	                //jQuery("#buddyforms_form_title").prev().css(\'color\',\'red\');
+	                //jQuery("#buddyforms_form_title").prev().css('color','red');
 	                label.insertBefore("#buddyforms_form_content");
+	            } else if(element.is("input[type=\"radio\"]")) {
+	                label.insertBefore(element)
 	            } else {
 	                label.insertAfter(element)
 	            }


### PR DESCRIPTION
Anmerkung: setzt das errorlabel nicht zwischen radiobutton und die beschriftung des buttons sondern "vor" den ersten radiobutton - sieht besser aus